### PR TITLE
feat(products/[id]): 商品バリエーションの表示方法を改善

### DIFF
--- a/app/(routes)/products/[id]/ProductActions.tsx
+++ b/app/(routes)/products/[id]/ProductActions.tsx
@@ -12,10 +12,14 @@ export function ProductActions({ cartId, variants }: { cartId: number, variants:
         { variants.map((v: any) => (
           <div
             key={v.id}
-            className="border-gray-400 border rounded-sm px-4 py-4 mb-2 text-sm flex justify-between"
+            className="items-center border-gray-400 border rounded-sm px-4 py-4 mb-2 text-sm flex justify-between"
+            style={{ borderColor: "blue" }}
           >
             <span>{ v.name }</span>
-            <span className="mr-4">¥{ v.price }</span>
+            <div className="flex items-center">
+              <span className="text-lg mr-2">¥{ v.price }</span>
+              <span className="text-sm">(税込)</span>
+            </div>
           </div>
         ))}
       </div>

--- a/app/(routes)/products/[id]/ProductActions.tsx
+++ b/app/(routes)/products/[id]/ProductActions.tsx
@@ -13,7 +13,8 @@ export function ProductActions({ cartId, variants }: { cartId: number, variants:
           <div
             key={v.id}
             className="items-center border-gray-400 border rounded-sm px-4 py-4 mb-2 text-sm flex justify-between"
-            style={{ borderColor: "blue" }}
+            style={ variantId === v.id ? { borderColor: "blue" } : {}}
+            onClick={() => setVariantId(v.id)}
           >
             <span>{ v.name }</span>
             <div className="flex items-center">

--- a/app/(routes)/products/[id]/ProductActions.tsx
+++ b/app/(routes)/products/[id]/ProductActions.tsx
@@ -7,18 +7,18 @@ export function ProductActions({ cartId, variants }: { cartId: number, variants:
 
   return (
     <div>
-      <p>選択：</p>
-      <select
-        name="variantId"
-        id="variantId"
-        className="border px-4 py-2 mb-4"
-        value={variantId}
-        onChange={ e  => setVariantId(e.target.value)}
-      >
+      <p className="mb-4">選択：</p>
+      <div className="mb-8">
         { variants.map((v: any) => (
-          <option key={v.id} value={v.id} >{v.name}</option>
+          <div
+            key={v.id}
+            className="border-gray-400 border rounded-sm px-4 py-4 mb-2 text-sm flex justify-between"
+          >
+            <span>{ v.name }</span>
+            <span className="mr-4">¥{ v.price }</span>
+          </div>
         ))}
-      </select>
+      </div>
       <AddItemToCartForm cartId={cartId} variantId={variantId} />
     </div>
   )

--- a/app/(routes)/products/[id]/ProductImageView.tsx
+++ b/app/(routes)/products/[id]/ProductImageView.tsx
@@ -8,10 +8,10 @@ export default async function ProductImageView({ productId }: { productId: numbe
 
   return (
     <div>
-      <Image src={product.thumbnailImageUrl} alt="product img" width={1080} height={720}/>
+      <Image src={product.thumbnailImageUrl} alt="product img" width={1080} height={720} loading="eager" />
       <div className="flex">
         { variants.map((v: any) => (
-          <Image key={v.id} src={v.imageUrl} alt="product variant img" width={360} height={240} />
+          <Image key={v.id} src={v.imageUrl} alt="product variant img" width={360} height={240} style={{ width: "25%", height: "auto" }}/>
         ))}          
       </div>
     </div>

--- a/app/(routes)/products/[id]/page.tsx
+++ b/app/(routes)/products/[id]/page.tsx
@@ -16,9 +16,9 @@ export default async function Page({ params }: {
   if(!cart) throw new Error("Cart not found")
   
   return (
-    <div className="flex">
+    <div>
       <ProductImageView productId={product.id} />
-      <div className="px-12">
+      <div>
         <h1 className="text-2xl mt-4 mb-2">{product.name}</h1>
         <h2 className="text-xl">¥{minPrice}</h2>
         <p className="py-2">カテゴリー：{product.category || "カテゴリー指定なし"}</p>

--- a/app/(routes)/products/[id]/page.tsx
+++ b/app/(routes)/products/[id]/page.tsx
@@ -16,17 +16,19 @@ export default async function Page({ params }: {
   if(!cart) throw new Error("Cart not found")
   
   return (
-    <div>
+    <div className="flex justify-between">
       <ProductImageView productId={product.id} />
-      <div>
-        <h1 className="text-2xl mt-4 mb-2">{product.name}</h1>
-        <h2 className="text-xl">¥{minPrice}</h2>
-        <p className="py-2">カテゴリー：{product.category || "カテゴリー指定なし"}</p>
-        <div className="my-4 py-2">
-          <h2 className="text-xl">詳細情報</h2>
-          <p>{product.description || "詳細情報の記入なし"}</p>
+      <div className="w-1/4">
+        <div className="w-3/4 mx-auto">
+          <h1 className="text-2xl mt-4 mb-2">{product.name}</h1>
+          <h2 className="text-xl">¥{minPrice}</h2>
+          <p className="py-2">カテゴリー：{product.category || "カテゴリー指定なし"}</p>
+          <div className="my-4 py-2">
+            <h2 className="text-xl">詳細情報</h2>
+            <p>{product.description || "詳細情報の記入なし"}</p>
+          </div>
+          <ProductActions cartId={cart.id} variants={variants} />
         </div>
-        <ProductActions cartId={cart.id} variants={variants} />
       </div>
     </div>
   )


### PR DESCRIPTION
## 背景

商品１にバリエーションAとBがあった時、セレクトボックスを開かないとバリエーションが見えなかった

## 変更

デフォルトでバリエーションをリスト表示

例)アクスタにキャラAとBがある場合、
キャラA
キャラB

## 影響範囲

`/products/[id]/page.tsx`

## 確認事項

- [ ] バリエーションがリスト表示されること
- [ ] バリエーションをクリックで切り替えできる
- [ ] 選択中のバリエーションをカートに追加できる